### PR TITLE
Only write summary if we are in streaming mode

### DIFF
--- a/src/cli/CliPrettyOutput.ts
+++ b/src/cli/CliPrettyOutput.ts
@@ -93,8 +93,11 @@ export class CliPrettyOutput extends CliActionOutput {
   }
 
   close() {
-    this.writeSummary();
-    clearInterval(this.summaryInterval);
+    if (this.summaryInterval) {
+      this.writeSummary();
+      clearInterval(this.summaryInterval);
+      this.summaryInterval = null;
+    }
   }
 
   compileError(err: Error) {


### PR DESCRIPTION
# Problem

The summary appears when running a single action
```
$  ./sqrl run samples/hello.sqrl -s 'Name="Josh"' Text
✓ 2018-12-10 16:10 action was allowed.
Text="Hello, Josh!"

2018-12-10 16:10:32 0 actions blocked, 1 actions allowed (24.4/sec)
```

# Solution

The summary only makes sense when running in streaming mode. Don't display it for single actions.

# Result

```
$ ./sqrl run samples/hello.sqrl -s 'Name="Josh"' Text
✓ 2018-12-10 16:13 action was allowed.
Text="Hello, Josh!"
```
