### PR TITLE
Improve error handling in SQRL repl

### DIFF
--- a/packages/sqrl/src/testing/SqrlTest.ts
+++ b/packages/sqrl/src/testing/SqrlTest.ts
@@ -93,13 +93,20 @@ export class SqrlTest {
     const codedErrors = [];
     const executions: SqrlExecutionState[] = [];
 
-    const execute = async (wait = false) => {
-      const state = await this.executeStatements(ctx, assertions, wait);
-      executions.push(state);
+    const prevStatements = [...this.statements];
 
-      codedErrors.push(...state.loggedCodedErrors);
-      assertions = [];
-      return state;
+    const execute = async (wait = false) => {
+      try {
+        const state = await this.executeStatements(ctx, assertions, wait);
+        executions.push(state);
+        codedErrors.push(...state.loggedCodedErrors);
+        assertions = [];
+        return state;
+      } catch (err) {
+        // If we hit an error, don't save the statements that caused the error.
+        this.statements = prevStatements;
+        throw err;
+      }
     };
 
     for (const statement of statements) {


### PR DESCRIPTION
# Problem

An error in the SQRL repl will keep occurring for that whole session:

```
sqrl> Username
'test'
sqrl> foo
Feature was not defined: foo
sqrl> Username
Feature was not defined: foo
```


# Solution

If `SqrlTest` throws it should not make any changes to its internal state.

# Result

```
$ ./sqrl repl
sqrl> LET Foo := foo();
Function not found: foo
sqrl> LET Name := 'josh'
'josh'
sqrl> foo()
Function not found: foo
sqrl> Name
'josh'
sqrl>
```