### PR TITLE
Add support for `-s ActionData=@data.json` in cli

### DIFF
--- a/packages/sqrl/src/testing/SqrlTest.ts
+++ b/packages/sqrl/src/testing/SqrlTest.ts
@@ -35,7 +35,7 @@ export class SqrlTest {
   extendTimeout: () => void;
   allowPrivate: boolean;
   calculateCost: boolean;
-  setFeatures;
+  inputs: FeatureMap;
   mutate: MutationCallback | null;
   featureTimeout: number;
   manipulatorFactory: (() => Manipulator) | null;
@@ -45,7 +45,7 @@ export class SqrlTest {
     private functionRegistry: SqrlFunctionRegistry,
     props: {
       files?: any;
-      setFeatures?: FeatureMap;
+      inputs?: FeatureMap;
       allowPrivate?: boolean;
       extendTimeout?: () => void;
       calculateCost?: boolean;
@@ -68,7 +68,7 @@ export class SqrlTest {
     this.mutate = props.mutate || null;
     this.allowPrivate = props.allowPrivate || false;
     this.calculateCost = props.calculateCost || false;
-    this.setFeatures = props.setFeatures;
+    this.inputs = props.inputs || {};
     this.filesystem = props.filesystem || null;
 
     // Keep track of the actual sqrl statements being run
@@ -198,7 +198,7 @@ export class SqrlTest {
         featureTimeout: this.featureTimeout,
         ruleSpecs: processed.ruleSpec
       },
-      this.setFeatures
+      this.inputs
     );
 
     await state.fetchClock();


### PR DESCRIPTION
# Problem

Tutorial was confusing requiring `loadJson` to be replaced with `input()` and back at various points.

"If you were to run this in production, you'd replace the call to loadJson("tweet.json") with input() to read the next action from the service. But for the purposes of this tutorial, let's stick with a static JSON file."


# Solution

Keep it as input, and provide the file data through `-s` in the cli

# Result

```
$ ./sqrl repl main.sqrl -s ActionData=@tweet.json
sqrl> Username
"floydophone"
```