### PR TITLE
Fix wikipedia tutorial

### DIFF
--- a/examples/wikipedia/features.sqrl
+++ b/examples/wikipedia/features.sqrl
@@ -11,6 +11,6 @@ LET OldRev := jsonValue(EventData, "$.revision.old");
 LET NewRev := jsonValue(EventData, "$.revision.new");
 LET DiffUrl := concat(
     "https://", Domain, "/w/index.php?",
-    "title=", urlEncode(Title), "&type=revision&",
+    "title=", escapeURI(Title), "&type=revision&",
     "diff=", NewRev, "&oldid=", OldRev
 );

--- a/website/source/examples/wikipedia.md
+++ b/website/source/examples/wikipedia.md
@@ -8,7 +8,7 @@ Once you get a little further, we have a demonstration that looks for a set of b
 ```
 git clone git@github.com:twitter/sqrl
 cd sqrl/examples/wikipedia
-npx wikipedia-diff-stream | sqrl run main.sqrl --stream=EventData --only-blocked
+npx wikipedia-diff-stream en.wikipedia.org | sqrl run main.sqrl --stream=EventData --only-blocked
 
 ...
 ✗ 2018-11-15 11:25 action was blocked.


### PR DESCRIPTION
# Problem

Wikipedia tutorial doesn't work.

# Solution

Updated the sqrl to use encodeURI, fixed the stream arg in the cli and updated the docs.

# Result

Now it works! 💃 