### PR TITLE
FunctionRegistry => Instance

### DIFF
--- a/examples/sqrl-example-functions/src/index.ts
+++ b/examples/sqrl-example-functions/src/index.ts
@@ -3,10 +3,10 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { AT, FunctionRegistry, Execution } from "sqrl";
+import { AT, Instance, Execution } from "sqrl";
 
-export function register(registry: FunctionRegistry) {
-  registry.register(
+export function register(instance: Instance) {
+  instance.register(
     // @todo: Add type for name once it's required
     async function sayHello(state: Execution, name) {
       return "Hello, " + name + "!";

--- a/packages/sqrl-cli-functions/src/BlockFunctions.ts
+++ b/packages/sqrl-cli-functions/src/BlockFunctions.ts
@@ -1,4 +1,4 @@
-import { WhenCause, AT, FunctionRegistry, Execution } from "sqrl";
+import { WhenCause, AT, Instance, Execution } from "sqrl";
 import { CliManipulator } from "./CliManipulator";
 
 /**
@@ -7,8 +7,8 @@ import { CliManipulator } from "./CliManipulator";
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export function registerBlockFunctions(registry: FunctionRegistry) {
-  registry.registerStatement(
+export function registerBlockFunctions(instance: Instance) {
+  instance.registerStatement(
     "SqrlBlockStatements",
     async function blockAction(state: Execution, cause: WhenCause) {
       if (!(state.manipulator instanceof CliManipulator)) {
@@ -24,7 +24,7 @@ export function registerBlockFunctions(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlBlockStatements",
     async function whitelistAction(state: Execution, cause: WhenCause) {
       if (!(state.manipulator instanceof CliManipulator)) {
@@ -40,7 +40,7 @@ export function registerBlockFunctions(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function wasBlocked(state: Execution) {
       if (!(state.manipulator instanceof CliManipulator)) {
         throw new Error("Expected CliManipulator for SimpleBlockService");

--- a/packages/sqrl-cli-functions/src/SourceFunctions.ts
+++ b/packages/sqrl-cli-functions/src/SourceFunctions.ts
@@ -2,7 +2,7 @@ import {
   AT,
   CallAst,
   Ast,
-  FunctionRegistry,
+  Instance,
   Execution,
   AstBuilder,
   CompileState
@@ -14,8 +14,8 @@ import {
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export function registerSourceFunction(registry: FunctionRegistry) {
-  registry.registerSync(
+export function registerSourceFunction(instance: Instance) {
+  instance.registerSync(
     function allSource(state, props = {}) {
       return state.sourcePrinter.getHumanAllSource(props);
     },
@@ -26,7 +26,7 @@ export function registerSourceFunction(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function featureSource(state: Execution, featureName, props = {}) {
       return state.getSourcePrinter().getSourceForSlotName(featureName, props);
     },
@@ -37,7 +37,7 @@ export function registerSourceFunction(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlLogStatements",
     async function _printSource(state: Execution, featureName?: string) {
       // tslint:disable-next-line:no-console
@@ -48,7 +48,7 @@ export function registerSourceFunction(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlLogStatements",
     async function printAllSource(state: Execution) {
       state.getSourcePrinter().printAllSource();
@@ -60,7 +60,7 @@ export function registerSourceFunction(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerTransform(
+  instance.registerTransform(
     function printSource(state: CompileState, ast: CallAst): Ast {
       const arg = ast.args[0];
       if (arg.type !== "feature") {
@@ -75,7 +75,7 @@ export function registerSourceFunction(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerTransform(
+  instance.registerTransform(
     function source(state: CompileState, ast: CallAst): Ast {
       const feature = ast.args[0];
       if (feature.type !== "feature") {

--- a/packages/sqrl-cli-functions/src/index.ts
+++ b/packages/sqrl-cli-functions/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 import {
-  FunctionRegistry,
+  Instance,
   CompileState,
   CallAst,
   AstBuilder,
@@ -18,11 +18,11 @@ import { registerSourceFunction } from "./SourceFunctions";
 import { registerBlockFunctions } from "./BlockFunctions";
 export { CliManipulator } from "./CliManipulator";
 
-export function register(registry: FunctionRegistry) {
-  registerSourceFunction(registry);
-  registerBlockFunctions(registry);
+export function register(instance: Instance) {
+  registerSourceFunction(instance);
+  registerBlockFunctions(instance);
 
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlLogStatements",
     async function log(state: Execution, format: string, ...args) {
       const message = util.format(format, ...args);
@@ -39,7 +39,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlLogStatements",
     async function _logFeature(state: Execution, name: string, value: any) {
       if (!(state.manipulator instanceof CliManipulator)) {
@@ -54,7 +54,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerTransform(
+  instance.registerTransform(
     function logFeature(state: CompileState, ast: CallAst) {
       const [feature] = ast.args;
       if (feature.type !== "feature") {

--- a/packages/sqrl-cli/src/index.ts
+++ b/packages/sqrl-cli/src/index.ts
@@ -8,7 +8,7 @@
 import { cliMain, getCliOutput } from "./cli/CliMain";
 import { promiseFinally } from "sqrl-common";
 import { CloseableGroup } from "./jslib/Closeable";
-import { FunctionRegistry } from "sqrl";
+import { Instance } from "sqrl";
 import { CliOutput } from "./cli/CliOutput";
 import { CliError } from "./cli/CliError";
 import { parseArgs, CliArgs } from "./cli/CliArgs";
@@ -17,7 +17,11 @@ export { CliArgs };
 export { parseArgs };
 export { cliMain };
 
-export function run(registerFunctions?: (registry: FunctionRegistry) => void) {
+export function run(
+  options: {
+    register?: (instance: Instance) => Promise<void>;
+  } = {}
+) {
   const closeables = new CloseableGroup();
   let exitCode = 1;
   let output: CliOutput;
@@ -37,7 +41,7 @@ export function run(registerFunctions?: (registry: FunctionRegistry) => void) {
   }
 
   promiseFinally(
-    cliMain(args, closeables, { registerFunctions, output })
+    cliMain(args, closeables, { register: options.register, output })
       .then(() => {
         exitCode = 0;
       })

--- a/packages/sqrl-cli/src/renderFunctionsHelp.ts
+++ b/packages/sqrl-cli/src/renderFunctionsHelp.ts
@@ -4,13 +4,13 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 import chalk from "chalk";
-import { FunctionRegistry, STANDARD_LIBRARY } from "sqrl";
+import { Instance, STANDARD_LIBRARY } from "sqrl";
 
 interface FunctionDescriptions {
   [func: string]: string;
 }
 
-export function renderFunctionsHelp(functionRegistry: FunctionRegistry) {
+export function renderFunctionsHelp(instance: Instance) {
   const stdlib: {
     [name: string]: FunctionDescriptions;
   } = {};
@@ -18,7 +18,7 @@ export function renderFunctionsHelp(functionRegistry: FunctionRegistry) {
     [name: string]: FunctionDescriptions;
   } = {};
   for (const [name, props] of Object.entries(
-    functionRegistry._functionRegistry.functionProperties
+    instance._instance.functionProperties
   ).sort()) {
     if (!name.startsWith("_")) {
       let args = "";

--- a/packages/sqrl-cli/src/repl/SqrlRepl.ts
+++ b/packages/sqrl-cli/src/repl/SqrlRepl.ts
@@ -14,7 +14,7 @@ import * as expandTilde from "expand-tilde";
 import { existsSync, readFileSync, appendFileSync } from "fs";
 import { EventEmitter } from "eventemitter3";
 import { Ast, StatementAst } from "sqrl/lib/ast/Ast";
-import { SqrlCompileError, SqrlObject, Context, FunctionRegistry } from "sqrl";
+import { SqrlCompileError, SqrlObject, Context, Instance } from "sqrl";
 import chalk from "chalk";
 import { SlotMissingCallbackError } from "sqrl/lib/execute/SqrlExecutionState";
 import { isValidFeatureName } from "sqrl/lib/feature/FeatureName";
@@ -33,7 +33,7 @@ export class SqrlRepl extends EventEmitter {
   private busy = new Semaphore();
 
   constructor(
-    private functionRegistry: FunctionRegistry,
+    private instance: Instance,
     private test: SqrlTest,
     options: {
       traceFactory: () => Context;
@@ -54,7 +54,7 @@ export class SqrlRepl extends EventEmitter {
       returnFeature = input.trim();
     } else {
       const ast = parseRepl(input, {
-        customFunctions: this.functionRegistry._functionRegistry.customFunctions
+        customFunctions: this.instance._instance.customFunctions
       });
       const statements = ast.statements;
       if (!statements.length) {
@@ -67,8 +67,8 @@ export class SqrlRepl extends EventEmitter {
       // If it's a call, make sure it's to a statement otherwise treat as an expression
       if (last.type === "call") {
         if (
-          this.functionRegistry._functionRegistry.has(last.func) &&
-          !this.functionRegistry._functionRegistry.isStatement(last.func)
+          this.instance._instance.has(last.func) &&
+          !this.instance._instance.isStatement(last.func)
         ) {
           last = {
             type: "expr",
@@ -105,7 +105,7 @@ export class SqrlRepl extends EventEmitter {
   }
 
   private printHelp() {
-    console.log(renderFunctionsHelp(this.functionRegistry));
+    console.log(renderFunctionsHelp(this.instance));
   }
 
   private async eval(cmd, context, filename) {

--- a/packages/sqrl-load-functions/src/index.ts
+++ b/packages/sqrl-load-functions/src/index.ts
@@ -12,7 +12,7 @@
 import * as path from "path";
 import * as yaml from "js-yaml";
 import {
-  FunctionRegistry,
+  Instance,
   CompileState,
   CallAst,
   ConstantAst,
@@ -31,8 +31,8 @@ function loadFile(state: CompileState, sourceAst: Ast, filePath: string) {
   return buffer.toString("utf-8");
 }
 
-export function register(registry: FunctionRegistry) {
-  registry.registerTransform(
+export function register(instance: Instance) {
+  instance.registerTransform(
     function loadJson(state: CompileState, ast: CallAst): Ast {
       const pathAst = ast.args[0] as ConstantAst;
       const parsed = yaml.safeLoad(loadFile(state, ast, pathAst.value));
@@ -45,7 +45,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerTransform(
+  instance.registerTransform(
     function loadYaml(state: CompileState, ast: CallAst): Ast {
       const pathAst = ast.args[0] as ConstantAst;
       const parsed = yaml.safeLoad(loadFile(state, ast, pathAst.value));
@@ -59,7 +59,7 @@ export function register(registry: FunctionRegistry) {
   );
 
   // Used by patternMatches
-  registry.registerTransform(
+  instance.registerTransform(
     function loadLines(state: CompileState, ast: CallAst): Ast {
       const pathAst = ast.args[0] as ConstantAst;
       const parsed = loadFile(state, pathAst, pathAst.value)

--- a/packages/sqrl-redis-functions/__tests__/countUnique_1.spec.ts
+++ b/packages/sqrl-redis-functions/__tests__/countUnique_1.spec.ts
@@ -6,7 +6,7 @@
 import { createSimpleContext, Execution, SimpleManipulator } from "sqrl";
 import * as moment from "moment";
 import { jsonTemplate } from "sqrl-common";
-import { runSqrl, buildRedisTestFunctionRegistry } from "./helpers/runSqrl";
+import { runSqrl, buildRedisTestInstance } from "./helpers/runSqrl";
 
 test("debug", async () =>
   runSqrl(`
@@ -186,7 +186,7 @@ test("unique aliases work", async () => {
   let state: Execution;
   let manipulator: SimpleManipulator;
 
-  const functionRegistry = await buildRedisTestFunctionRegistry({
+  const instance = await buildRedisTestInstance({
     fixedDate: "2016-09-26T20:56:14.538Z"
   });
   const run = async (
@@ -200,7 +200,7 @@ LET Ip := ${JSON.stringify(values.Ip || "1.2.3.4")};
 LET Target := ${JSON.stringify(values.Target || "greg")};
 LET UniquesByIp := countUnique(${countStatement} GROUP BY Ip LAST WEEK);
     `,
-      { functionRegistry }
+      { instance }
     );
 
     const state = rv.executions.shift();

--- a/packages/sqrl-redis-functions/__tests__/helpers/runSqrl.ts
+++ b/packages/sqrl-redis-functions/__tests__/helpers/runSqrl.ts
@@ -5,38 +5,38 @@
  */
 import {
   runSqrlTest as runLibSqrl,
-  buildTestFunctionRegistry,
-  FunctionRegistry,
+  buildTestInstance,
+  Instance,
   Logger
 } from "sqrl";
 import { register } from "../../src";
 
-export async function buildRedisTestFunctionRegistry(
+export async function buildRedisTestInstance(
   options: {
     fixedDate?: string;
   } = {}
 ) {
-  const functionRegistry = await buildTestFunctionRegistry({
+  const instance = await buildTestInstance({
     config: {
       "testing.fixed-date": options.fixedDate
     }
   });
-  register(functionRegistry);
-  return functionRegistry;
+  register(instance);
+  return instance;
 }
 
 export async function runSqrl(
   sqrl: string,
   options: {
-    functionRegistry?: FunctionRegistry;
+    instance?: Instance;
     logger?: Logger;
     fixedDate?: string;
   } = {}
 ) {
   return runLibSqrl(sqrl, {
-    functionRegistry:
-      options.functionRegistry ||
-      (await buildRedisTestFunctionRegistry({
+    instance:
+      options.instance ||
+      (await buildRedisTestInstance({
         fixedDate: options.fixedDate
       })),
     logger: options.logger

--- a/packages/sqrl-redis-functions/__tests__/include.spec.ts
+++ b/packages/sqrl-redis-functions/__tests__/include.spec.ts
@@ -4,14 +4,14 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 // tslint:disable:no-submodule-imports (@TODO)
-import { buildRedisTestFunctionRegistry } from "./helpers/runSqrl";
+import { buildRedisTestInstance } from "./helpers/runSqrl";
 import { executableFromFilesystem, VirtualFilesystem } from "sqrl";
 import "jest-extended";
 
 test("works with counts", async () => {
-  const functionRegistry = await buildRedisTestFunctionRegistry();
+  const instance = await buildRedisTestInstance();
   const executable = await executableFromFilesystem(
-    functionRegistry,
+    instance,
     new VirtualFilesystem({
       "x.sqrl": `
   LET Count := count(BY Ip);

--- a/packages/sqrl-redis-functions/__tests__/rateLimit.spec.ts
+++ b/packages/sqrl-redis-functions/__tests__/rateLimit.spec.ts
@@ -6,17 +6,17 @@
 type autogen_any = any;
 
 import { jsonTemplate } from "sqrl-common";
-import { runSqrl, buildRedisTestFunctionRegistry } from "./helpers/runSqrl";
-import { FunctionRegistry, TestLogger } from "sqrl";
+import { runSqrl, buildRedisTestInstance } from "./helpers/runSqrl";
+import { Instance, TestLogger } from "sqrl";
 import "jest-extended";
 
-let functionRegistry: FunctionRegistry;
+let instance: Instance;
 beforeEach(async () => {
-  functionRegistry = await buildRedisTestFunctionRegistry();
+  instance = await buildRedisTestInstance();
 });
 
 async function getResult(sqrl: string) {
-  return runSqrl(sqrl, { functionRegistry }).then(({ lastExecution }) => {
+  return runSqrl(sqrl, { instance }).then(({ lastExecution }) => {
     return lastExecution.fetchValue("Result");
   });
 }
@@ -36,7 +36,7 @@ test("Basic test works", async () => {
     ASSERT rateLimited(BY Ip MAX 2 EVERY DAY) = false;
     EXECUTE;
     `,
-    { functionRegistry }
+    { instance }
   );
 });
 
@@ -99,7 +99,7 @@ test("works with retries", () =>
       ASSERT Result = 0; EXECUTE;
       ASSERT Blocked = true;
     `,
-    { functionRegistry }
+    { instance }
   ));
 
 test("returns rate limited multi values", () =>
@@ -127,7 +127,7 @@ test("returns rate limited multi values", () =>
     "lunch was good"
   ];
 `,
-    { functionRegistry }
+    { instance }
   ));
 
 test("works with multiple values", async () => {
@@ -139,7 +139,7 @@ LET Value1 := ${JSON.stringify(ip)};
 LET Value2 := ${JSON.stringify(machine)};
 LET Result := rateLimit(BY Value1, Value2 MAX 3 EVERY 60 SECOND);
     `,
-      { functionRegistry, logger }
+      { instance, logger }
     ).then(({ lastExecution }) => {
       return lastExecution.fetchValue("Result");
     });

--- a/packages/sqrl-redis-functions/__tests__/sessionize.spec.ts
+++ b/packages/sqrl-redis-functions/__tests__/sessionize.spec.ts
@@ -4,13 +4,13 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { runSqrl, buildRedisTestFunctionRegistry } from "./helpers/runSqrl";
-import { FunctionRegistry } from "sqrl";
+import { runSqrl, buildRedisTestInstance } from "./helpers/runSqrl";
+import { Instance } from "sqrl";
 import { jsonTemplate } from "sqrl-common";
 
-let functionRegistry: FunctionRegistry;
+let instance: Instance;
 beforeEach(async () => {
-  functionRegistry = await buildRedisTestFunctionRegistry();
+  instance = await buildRedisTestInstance();
 });
 
 test("basic test works", async () => {
@@ -51,6 +51,6 @@ test("basic test works", async () => {
     ASSERT SessionAge = null;
     EXECUTE;
     `,
-    { functionRegistry }
+    { instance }
   );
 });

--- a/packages/sqrl-redis-functions/src/CountFunctions.ts
+++ b/packages/sqrl-redis-functions/src/CountFunctions.ts
@@ -11,7 +11,7 @@ import {
   CompileState,
   Context,
   Execution,
-  FunctionRegistry,
+  Instance,
   sqrlInvariant,
   CountValidTimespan,
   Ast,
@@ -263,10 +263,10 @@ export function ensureCounterBump(
 }
 
 export function registerCountFunctions(
-  registry: FunctionRegistry,
+  instance: Instance,
   service: CountService
 ) {
-  registry.registerSync(
+  instance.registerSync(
     function _getBumpBy(bumpBy: number) {
       if (typeof bumpBy !== "number") {
         return null;
@@ -278,7 +278,7 @@ export function registerCountFunctions(
     }
   );
 
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlCountStatements",
     async function _bumpCount(state, keys, by, flags) {
       if (!Array.isArray(keys)) {
@@ -303,7 +303,7 @@ export function registerCountFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     function _fetchCountsFromDb(state: Execution, keys, suffix) {
       return service.fetch(state.ctx, state.getClockMs(), keys, suffix);
     },
@@ -313,7 +313,7 @@ export function registerCountFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     async function _fetchTrendingDetails(
       state,
       keys,
@@ -365,7 +365,7 @@ export function registerCountFunctions(
     }
   );
 
-  registry.registerCustom(
+  instance.registerCustom(
     function trending(state: CompileState, ast: CustomCallAst): Ast {
       const args: TrendingArguments = parse(ast.source, {
         startRule: "TrendingArguments"
@@ -502,7 +502,7 @@ export function registerCountFunctions(
     );
   }
 
-  registry.registerCustom(
+  instance.registerCustom(
     function count(state: CompileState, ast: CustomCallAst): Ast {
       const args: CountArguments = parse(ast.source, {
         startRule: "CountArguments"

--- a/packages/sqrl-redis-functions/src/CountUniqueFunctions.ts
+++ b/packages/sqrl-redis-functions/src/CountUniqueFunctions.ts
@@ -10,7 +10,7 @@ import {
   AstBuilder,
   Context,
   Execution,
-  FunctionRegistry,
+  Instance,
   SqrlKey,
   SqrlObject,
   CompileState,
@@ -78,10 +78,10 @@ export interface CountUniqueService {
 }
 
 export function registerCountUniqueFunctions(
-  registry: FunctionRegistry,
+  instance: Instance,
   service: CountUniqueService
 ) {
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlCountUniqueStatements",
     async function _bumpCountUnique(state: Execution, keys, uniques) {
       uniques = SqrlObject.ensureBasic(uniques);
@@ -111,7 +111,7 @@ export function registerCountUniqueFunctions(
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function _unionCountUnique(left, right) {
       invariant(
         left instanceof Set && right instanceof Set,
@@ -131,7 +131,7 @@ export function registerCountUniqueFunctions(
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function _intersectCountUnique(left, right) {
       invariant(
         left instanceof Set && right instanceof Set,
@@ -151,7 +151,7 @@ export function registerCountUniqueFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     function _fetchCountUnique(state, keys, windowMs, uniques) {
       uniques = SqrlObject.ensureBasic(uniques).map(value => {
         if (typeof value === "number") {
@@ -175,7 +175,7 @@ export function registerCountUniqueFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     async function _fetchCountUniqueElements(
       state,
       keys,
@@ -218,7 +218,7 @@ export function registerCountUniqueFunctions(
     }
   );
 
-  registry.registerCustom(
+  instance.registerCustom(
     function countUnique(state: CompileState, ast: CustomCallAst): Ast {
       const args: CountUniqueArguments = parse(ast.source, {
         startRule: "CountUniqueArguments"

--- a/packages/sqrl-redis-functions/src/EntityFunctions.ts
+++ b/packages/sqrl-redis-functions/src/EntityFunctions.ts
@@ -5,7 +5,7 @@
  */
 import {
   AT,
-  FunctionRegistry,
+  Instance,
   CompileState,
   Execution,
   SqrlEntity,
@@ -36,10 +36,10 @@ async function toEntity(
 }
 
 export function registerEntityFunctions(
-  registry: FunctionRegistry,
+  instance: Instance,
   service: UniqueIdService
 ) {
-  registry.register(
+  instance.register(
     async function _entity(state: Execution, type: string, value) {
       // Handle common empty / null values
       if (value === null || typeof value === "undefined" || value === "") {
@@ -53,7 +53,7 @@ export function registerEntityFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     async function _entityList(state: Execution, type: string, arr: string[]) {
       if (type === null || arr === null || !Array.isArray(arr)) {
         return null;
@@ -69,7 +69,7 @@ export function registerEntityFunctions(
     }
   );
 
-  registry.registerTransform(
+  instance.registerTransform(
     function entity(state: CompileState, ast: CallAst): Ast {
       return AstBuilder.call("_entity", ast.args);
     },
@@ -80,7 +80,7 @@ export function registerEntityFunctions(
     }
   );
 
-  registry.registerTransform(
+  instance.registerTransform(
     function entityList(state: CompileState, ast: CallAst): Ast {
       return AstBuilder.call("_entityList", ast.args);
     },

--- a/packages/sqrl-redis-functions/src/LabelFunctions.ts
+++ b/packages/sqrl-redis-functions/src/LabelFunctions.ts
@@ -9,7 +9,7 @@ import { ensureArray } from "sqrl-common";
 import {
   Context,
   Execution,
-  FunctionRegistry,
+  Instance,
   Manipulator,
   WhenCause,
   SqrlEntity,
@@ -33,10 +33,10 @@ export interface LabelService {
 }
 
 export function registerLabelFunctions(
-  registry: FunctionRegistry,
+  instance: Instance,
   service: LabelService
 ) {
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlLabelStatements",
     async function addLabel(
       state: Execution,
@@ -64,7 +64,7 @@ export function registerLabelFunctions(
     }
   );
 
-  registry.registerStatement(
+  instance.registerStatement(
     "SqrlLabelStatements",
     async function removeLabel(
       state: Execution,
@@ -92,7 +92,7 @@ export function registerLabelFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     async function hasLabel(
       state: Execution,
       entity: SqrlEntity,

--- a/packages/sqrl-redis-functions/src/RateLimitFunctions.ts
+++ b/packages/sqrl-redis-functions/src/RateLimitFunctions.ts
@@ -10,7 +10,7 @@ import {
   AstBuilder,
   CallAst,
   Context,
-  FunctionRegistry,
+  Instance,
   CompileState,
   SqrlKey,
   AT,
@@ -107,10 +107,10 @@ function setupRateLimitAst(state: CompileState, ast: CustomCallAst) {
 }
 
 export function registerRateLimitFunctions(
-  registry: FunctionRegistry,
+  instance: Instance,
   service: RateLimitService
 ) {
-  registry.register(
+  instance.register(
     async function _fetchRateLimit(state: Execution, props) {
       if (props.keys === null) {
         return null;
@@ -123,7 +123,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     async function _fetchSession(state, props) {
       if (props.keys === null) {
         return null;
@@ -136,7 +136,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function _parseInt(val) {
       return typeof val !== "number" ? null : Math.floor(val);
     },
@@ -145,7 +145,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerTransform(
+  instance.registerTransform(
     function _getTokenAmount(state: CompileState, ast: CallAst): Ast {
       const tokenAmountAst = ast.args[0];
       sqrlInvariant(
@@ -160,7 +160,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerCustom(
+  instance.registerCustom(
     function rateLimit(state: CompileState, ast: CustomCallAst): Ast {
       const resultsAst = setupRateLimitAst(state, ast).resultsAst;
       return AstBuilder.call("min", [resultsAst]);
@@ -173,7 +173,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function _rateLimitedValues(state, keys, results) {
       if (keys.length !== results.length) {
         throw new Error("Mismatched # of keys and results");
@@ -194,7 +194,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerCustom(
+  instance.registerCustom(
     function rateLimitedValues(state: CompileState, ast: CustomCallAst): Ast {
       const { resultsAst, keysAst } = setupRateLimitAst(state, ast);
       return AstBuilder.call("_rateLimitedValues", [keysAst, resultsAst]);
@@ -207,7 +207,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerCustom(
+  instance.registerCustom(
     function rateLimited(state: CompileState, ast: CustomCallAst): Ast {
       const args: RateLimitArguments = parse(ast.source, {
         startRule: "RateLimitArguments"
@@ -246,7 +246,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function _sessionize(key, startMs) {
       startMs = SqrlObject.ensureBasic(startMs);
       return new SqrlSession(key, startMs);
@@ -256,7 +256,7 @@ export function registerRateLimitFunctions(
     }
   );
 
-  registry.registerCustom(
+  instance.registerCustom(
     function sessionize(state: CompileState, ast: CustomCallAst): Ast {
       const args: RateLimitArguments = parse(ast.source, {
         startRule: "RateLimitArguments"

--- a/packages/sqrl-redis-functions/src/index.ts
+++ b/packages/sqrl-redis-functions/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./RateLimitFunctions";
 import { LabelService, registerLabelFunctions } from "./LabelFunctions";
 import { RedisServices } from "./ServiceHelpers";
-import { FunctionRegistry } from "sqrl";
+import { Instance } from "sqrl";
 import { registerEntityFunctions } from "./EntityFunctions";
 import { UniqueIdService } from "./services/RedisUniqueId";
 
@@ -26,12 +26,12 @@ export interface RedisServices {
   uniqueId: UniqueIdService;
 }
 
-export function register(registry: FunctionRegistry) {
-  const services = new RedisServices(registry.getConfig());
+export function register(instance: Instance) {
+  const services = new RedisServices(instance.getConfig());
 
-  registerCountFunctions(registry, services.count);
-  registerCountUniqueFunctions(registry, services.countUnique);
-  registerEntityFunctions(registry, services.uniqueId);
-  registerLabelFunctions(registry, services.label);
-  registerRateLimitFunctions(registry, services.rateLimit);
+  registerCountFunctions(instance, services.count);
+  registerCountUniqueFunctions(instance, services.countUnique);
+  registerEntityFunctions(instance, services.uniqueId);
+  registerLabelFunctions(instance, services.label);
+  registerRateLimitFunctions(instance, services.rateLimit);
 }

--- a/packages/sqrl-text-functions/__tests__/helpers/textSqrlTest.ts
+++ b/packages/sqrl-text-functions/__tests__/helpers/textSqrlTest.ts
@@ -6,17 +6,17 @@
 import { register as registerTextFunctions } from "../../src";
 import { register as registerLoadFunctions } from "sqrl-load-functions";
 
-import { buildTestFunctionRegistry, runSqrlTest, Filesystem } from "sqrl";
+import { buildTestInstance, runSqrlTest, Filesystem } from "sqrl";
 
 interface Options {
   filesystem?: Filesystem;
 }
 
 export async function runTextSqrlTest(sqrl: string, options: Options) {
-  const functionRegistry = await buildTestFunctionRegistry();
+  const instance = await buildTestInstance();
 
   return runSqrlTest(sqrl, {
-    functionRegistry,
+    instance,
     register: async instance => {
       await registerLoadFunctions(instance);
       await registerTextFunctions(instance);

--- a/packages/sqrl-text-functions/src/PatternFunctions.ts
+++ b/packages/sqrl-text-functions/src/PatternFunctions.ts
@@ -10,7 +10,7 @@ import {
   ConstantAst,
   CompileState,
   Execution,
-  FunctionRegistry,
+  Instance,
   AstBuilder
 } from "sqrl";
 
@@ -20,10 +20,10 @@ export interface PatternService {
 }
 
 export function registerPatternFunctions(
-  registry: FunctionRegistry,
+  instance: Instance,
   service: PatternService
 ) {
-  registry.registerTransform(
+  instance.registerTransform(
     function patternMatches(state: CompileState, ast: CallAst): Ast {
       const nameAst = ast.args[0] as ConstantAst;
       return AstBuilder.call("_patternMatches", [
@@ -39,7 +39,7 @@ export function registerPatternFunctions(
     }
   );
 
-  registry.register(
+  instance.register(
     async function _patternMatches(
       state: Execution,
       patterns: string[],

--- a/packages/sqrl-text-functions/src/index.ts
+++ b/packages/sqrl-text-functions/src/index.ts
@@ -5,7 +5,7 @@
  */
 import {
   AT,
-  FunctionRegistry,
+  Instance,
   CompileState,
   Ast,
   AstBuilder,
@@ -16,10 +16,10 @@ import { InProcessPatternService } from "./InProcessPatternService";
 import { SimHash } from "simhash-js";
 import { createHash } from "crypto";
 
-export function register(registry: FunctionRegistry) {
+export function register(instance: Instance) {
   const jsSimhash = new SimHash();
 
-  registry.registerSync(
+  instance.registerSync(
     function sha256(data: Buffer | string): string {
       const hasher = createHash("sha256");
       if (data instanceof Buffer) {
@@ -37,7 +37,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function simhash(text: string) {
       const hashHex: string = jsSimhash.hash(text).toString(16);
       return hashHex.padStart(8, "0");
@@ -49,7 +49,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function _charGrams(string, gramSize) {
       const grams = [];
       for (let i = 0; i <= string.length - gramSize; i++) {
@@ -61,7 +61,7 @@ export function register(registry: FunctionRegistry) {
       args: [AT.any.string, AT.constant.number]
     }
   );
-  registry.registerTransform(
+  instance.registerTransform(
     function charGrams(state: CompileState, ast): Ast {
       const sizeAst = ast.args[1];
       sqrlInvariant(
@@ -78,7 +78,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function regexMatch(state, regex, string) {
       return string.match(new RegExp(regex, "g"));
     },
@@ -90,7 +90,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function regexTest(state, regex, string) {
       return new RegExp(regex, "g").test(string);
     },
@@ -102,7 +102,7 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registry.registerSync(
+  instance.registerSync(
     function regexReplace(state, regex, replacement, string) {
       return string.replace(new RegExp(regex, "g"), replacement);
     },
@@ -116,7 +116,7 @@ export function register(registry: FunctionRegistry) {
 
   const RE_EMAIL = new RegExp("[^\\d\\w]+", "ig");
 
-  registry.registerSync(
+  instance.registerSync(
     function normalizeEmail(state, email: string) {
       const [handle, domain] = email.toLowerCase().split("@", 2);
       return handle.split("+")[0].replace(RE_EMAIL, "") + "@" + domain;
@@ -128,5 +128,5 @@ export function register(registry: FunctionRegistry) {
     }
   );
 
-  registerPatternFunctions(registry, new InProcessPatternService());
+  registerPatternFunctions(instance, new InProcessPatternService());
 }

--- a/packages/sqrl/__tests__/helpers/TestFunctions.ts
+++ b/packages/sqrl/__tests__/helpers/TestFunctions.ts
@@ -3,13 +3,13 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { SqrlFunctionRegistry } from "../../src/function/FunctionRegistry";
+import { SqrlInstance } from "../../src/function/Instance";
 import { AstTypes as AT } from "../../src/ast/AstTypes";
 import { SqrlExecutionState } from "../../src/execute/SqrlExecutionState";
 import { Manipulator } from "../../src/api/execute";
 
-export function registerTestFunctions(registry: SqrlFunctionRegistry) {
-  registry.save(
+export function registerTestFunctions(instance: SqrlInstance) {
+  instance.save(
     function getSqrlOutput(state: SqrlExecutionState) {
       const manipulator: Manipulator = state.manipulator as any;
       return manipulator.getCurrentHumanOutput();

--- a/packages/sqrl/__tests__/helpers/runCompile.ts
+++ b/packages/sqrl/__tests__/helpers/runCompile.ts
@@ -5,7 +5,7 @@
  */
 import { compileParserStateAst } from "../../src/compile/SqrlCompile";
 import { SqrlParserState } from "../../src/compile/SqrlParserState";
-import { SqrlFunctionRegistry } from "../../src/function/FunctionRegistry";
+import { SqrlInstance } from "../../src/function/Instance";
 import { registerAllFunctions } from "../../src/function/registerAllFunctions";
 import { SqrlCompiledOutput } from "../../src/compile/SqrlCompiledOutput";
 import { statementsFromString } from "../../src/helpers/CompileHelpers";
@@ -16,21 +16,21 @@ import { FeatureMap } from "../../src/api/execute";
 import { SimpleManipulator } from "../../src/simple/SimpleManipulator";
 
 export async function runCompile(sqrl: string) {
-  const functionRegistry = new SqrlFunctionRegistry();
-  registerAllFunctions(functionRegistry);
+  const instance = new SqrlInstance();
+  registerAllFunctions(instance);
   const statements = statementsFromString(sqrl);
-  const parserState = new SqrlParserState({ functionRegistry, statements });
+  const parserState = new SqrlParserState({ instance, statements });
   compileParserStateAst(parserState);
   const compiledOutput = new SqrlCompiledOutput(parserState);
   const trace = createDefaultContext();
   const spec = compiledOutput.executableSpec;
-  const context = new JsExecutionContext(functionRegistry);
+  const context = new JsExecutionContext(instance);
   const executable = new SqrlExecutable(context, spec);
 
   return {
     compiledOutput,
     executable,
-    functionRegistry,
+    instance,
     trace
   };
 }

--- a/packages/sqrl/__tests__/registry/args.spec.ts
+++ b/packages/sqrl/__tests__/registry/args.spec.ts
@@ -3,12 +3,12 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { buildFunctionRegistry, AT, ArgumentCheck } from "../../src/index";
+import { createInstance, AT, ArgumentCheck } from "../../src/index";
 
 test("throw with out of order optional", async () => {
   function tryRegister(args: ArgumentCheck[]) {
-    const functionRegistry = buildFunctionRegistry();
-    functionRegistry.registerSync(
+    const instance = createInstance();
+    instance.registerSync(
       function hello() {
         return "world";
       },

--- a/packages/sqrl/__tests__/sqrl/include.spec.ts
+++ b/packages/sqrl/__tests__/sqrl/include.spec.ts
@@ -6,13 +6,13 @@
 import { runExecutable, fetchExecutableFeature } from "../helpers/runCompile";
 import {
   executableFromFilesystem,
-  buildTestFunctionRegistry,
+  buildTestInstance,
   VirtualFilesystem
 } from "../../src";
 
 test("supports include statements", async () => {
   const executable = await executableFromFilesystem(
-    await buildTestFunctionRegistry(),
+    await buildTestInstance(),
     new VirtualFilesystem({
       "sample.sqrl": `
     LET A := "Hello ";
@@ -55,7 +55,7 @@ LET NullMessage := concat(A, B, C);
 
 test("supports dynamic include", async () => {
   const executable = await executableFromFilesystem(
-    await buildTestFunctionRegistry(),
+    await buildTestInstance(),
     new VirtualFilesystem({
       "features/foo_action.sqrl": `
 LET Thing := "from foo action";
@@ -96,7 +96,7 @@ INCLUDE "features/\${Action}.sqrl";
   ).resolves.toEqual("from bar action");
   await expect(
     executableFromFilesystem(
-      await buildTestFunctionRegistry(),
+      await buildTestInstance(),
       new VirtualFilesystem({
         "features/foo_action.sqrl": `
 LET Thing := "from foo action";

--- a/packages/sqrl/__tests__/sqrl/let.spec.ts
+++ b/packages/sqrl/__tests__/sqrl/let.spec.ts
@@ -8,7 +8,7 @@ import {
   compileToExecution,
   fetchExecutableFeature
 } from "../helpers/runCompile";
-import { buildTestFunctionRegistry } from "../../src/testing/runSqrlTest";
+import { buildTestInstance } from "../../src/testing/runSqrlTest";
 import { executableFromFilesystem, VirtualFilesystem } from "../../src";
 import { runSqrlTest } from "../../src/simple/runSqrlTest";
 
@@ -93,7 +93,7 @@ test("supports where default values", async () => {
 
   await expect(
     executableFromFilesystem(
-      await buildTestFunctionRegistry(),
+      await buildTestInstance(),
       new VirtualFilesystem({
         "main.sqrl": `
     LET Act := "b";
@@ -110,7 +110,7 @@ test("supports where default values", async () => {
   );
 
   const executable = await executableFromFilesystem(
-    await buildTestFunctionRegistry(),
+    await buildTestInstance(),
     new VirtualFilesystem({
       "main.sqrl": `
     LET Choose := input();

--- a/packages/sqrl/__tests__/sqrl/rules.spec.ts
+++ b/packages/sqrl/__tests__/sqrl/rules.spec.ts
@@ -4,18 +4,18 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 import { AstTypes as AT } from "../../src/ast/AstTypes";
-import { SqrlFunctionRegistry } from "../../src/function/FunctionRegistry";
+import { SqrlInstance } from "../../src/function/Instance";
 import { registerAllFunctions } from "../../src/function/registerAllFunctions";
 import { SqrlTest } from "../../src/testing/SqrlTest";
 import { JestAssertService } from "sqrl-test-utils";
-import { buildTestFunctionRegistry } from "../../src/testing/runSqrlTest";
+import { buildTestInstance } from "../../src/testing/runSqrlTest";
 import { createSimpleContext } from "../../src";
 import { runSqrlTest } from "../../src/simple/runSqrlTest";
 
 test("rules work", async () => {
-  const functionRegistry = new SqrlFunctionRegistry();
-  registerAllFunctions(functionRegistry, { assert: new JestAssertService() });
-  const test = new SqrlTest(functionRegistry, {});
+  const instance = new SqrlInstance();
+  registerAllFunctions(instance, { assert: new JestAssertService() });
+  const test = new SqrlTest(instance, {});
 
   await test.run(
     createSimpleContext(),
@@ -29,11 +29,11 @@ test("rules work", async () => {
 });
 
 test("when context works", async () => {
-  const functionRegistry = await buildTestFunctionRegistry();
+  const instance = await buildTestInstance();
 
   let saveCount = 0;
   let savedContext = null;
-  functionRegistry._functionRegistry.save(
+  instance._instance.save(
     function saveContext(state, whenCause, word) {
       saveCount += 1;
       savedContext = {
@@ -63,7 +63,7 @@ test("when context works", async () => {
   WHEN RuleTwo THEN saveContext("should not fire");
   EXECUTE;
   `,
-    { functionRegistry }
+    { instance }
   );
 
   // We expect saveContext to only fire once
@@ -80,7 +80,7 @@ test("when context works", async () => {
 
   // Try fire it manually (without whenCause)
   await runSqrlTest('saveContext("manual!"); EXECUTE;', {
-    functionRegistry
+    instance
   });
   expect(saveCount).toEqual(2);
   expect(savedContext).toEqual({
@@ -99,7 +99,7 @@ test("when context works", async () => {
   WHEN RuleX THEN saveContext("fire!");
   EXECUTE;
   `,
-    { functionRegistry }
+    { instance }
   );
   expect(saveCount).toEqual(3);
   expect(savedContext).toEqual({

--- a/packages/sqrl/__tests__/sqrl/test.spec.ts
+++ b/packages/sqrl/__tests__/sqrl/test.spec.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { SqrlFunctionRegistry } from "../../src/function/FunctionRegistry";
+import { SqrlInstance } from "../../src/function/Instance";
 import { registerAllFunctions } from "../../src/function/registerAllFunctions";
 import { SqrlTest } from "../../src/testing/SqrlTest";
 import { JestAssertService } from "sqrl-test-utils";
@@ -12,12 +12,12 @@ import { SimpleContext } from "../../src/platform/Trace";
 import { getGlobalLogger } from "../../src/api/log";
 
 test("Basic test works", async () => {
-  const functionRegistry = new SqrlFunctionRegistry();
-  registerAllFunctions(functionRegistry, {
+  const instance = new SqrlInstance();
+  registerAllFunctions(instance, {
     assert: new JestAssertService()
   });
 
-  const test = new SqrlTest(functionRegistry, {});
+  const test = new SqrlTest(instance, {});
   const trace = new SimpleContext(
     new SimpleDatabaseSet("0"),
     getGlobalLogger()

--- a/packages/sqrl/__tests__/sqrl/wrappers.spec.ts
+++ b/packages/sqrl/__tests__/sqrl/wrappers.spec.ts
@@ -6,19 +6,19 @@
 import * as SQRL from "../../src/index";
 
 test("wrappers work", async () => {
-  const functionRegistry = SQRL.buildFunctionRegistry();
+  const instance = SQRL.createInstance();
 
-  functionRegistry.registerSync(function world() {
+  instance.registerSync(function world() {
     return "world";
   });
 
-  functionRegistry.registerTransform(function excl(state, ast) {
+  instance.registerTransform(function excl(state, ast) {
     return SQRL.AstBuilder.constant("!");
   });
 
   const ctx = SQRL.createSimpleContext();
   const executable = await SQRL.executableFromString(
-    functionRegistry,
+    instance,
     "LET X := concat('Hello ', world(), excl());"
   );
 

--- a/packages/sqrl/src/api/test.ts
+++ b/packages/sqrl/src/api/test.ts
@@ -5,7 +5,7 @@
  */
 import { SqrlTest } from "../testing/SqrlTest";
 
-export { buildTestFunctionRegistry } from "../testing/runSqrlTest";
+export { buildTestInstance } from "../testing/runSqrlTest";
 
 export { runSqrlTest } from "../simple/runSqrlTest";
 export { SimpleManipulator } from "../simple/SimpleManipulator";

--- a/packages/sqrl/src/ast/SqrlAstTransformer.ts
+++ b/packages/sqrl/src/ast/SqrlAstTransformer.ts
@@ -80,8 +80,8 @@ export default class SqrlAstTransformer {
   }
 
   assertArgs(ast: CallAst) {
-    const { functionRegistry } = this.state;
-    const props = functionRegistry.getProps(ast.func);
+    const { instance } = this.state;
+    const props = instance.getProps(ast.func);
 
     if (props.args) {
       AT.compileTypesInvariant(ast, props.args);
@@ -89,20 +89,20 @@ export default class SqrlAstTransformer {
   }
 
   customCall(ast: CustomCallAst) {
-    const { functionRegistry } = this.state;
-    const hasFunction = functionRegistry.has(ast.func);
+    const { instance } = this.state;
+    const hasFunction = instance.has(ast.func);
     sqrlInvariant(ast, hasFunction, "Function not found: " + ast.func);
-    const props = functionRegistry.getProps(ast.func);
+    const props = instance.getProps(ast.func);
     const transformed = props.customTransform(this.state, ast);
     return this.transform(transformed);
   }
   call(ast: CallAst) {
-    const { functionRegistry } = this.state;
+    const { instance } = this.state;
 
-    const hasFunction = functionRegistry.has(ast.func);
+    const hasFunction = instance.has(ast.func);
 
     sqrlInvariant(ast, hasFunction, "Function not found: " + ast.func);
-    const props = functionRegistry.getProps(ast.func);
+    const props = instance.getProps(ast.func);
 
     const isPrivate = ast.func.startsWith("_");
     if (isPrivate && ast.hasOwnProperty("location")) {
@@ -179,7 +179,7 @@ export default class SqrlAstTransformer {
         if (allConstant) {
           return {
             type: "constant",
-            value: this.state.functionRegistry.pureFunction[ast.func](
+            value: this.state.instance.pureFunction[ast.func](
               ...args.map(arg => arg.value)
             )
           };

--- a/packages/sqrl/src/compile/SqrlCompiledOutput.ts
+++ b/packages/sqrl/src/compile/SqrlCompiledOutput.ts
@@ -75,7 +75,7 @@ export class SqrlCompiledOutput extends SqrlParseInfo {
       });
 
       if (node.type === "call") {
-        cost += this.functionRegistry.getCost(node.func);
+        cost += this.instance.getCost(node.func);
       }
     });
 
@@ -109,7 +109,7 @@ export class SqrlCompiledOutput extends SqrlParseInfo {
 
     const ast: Ast = slot.finalizedAst();
 
-    const expr = processExprAst(ast, this, this.functionRegistry);
+    const expr = processExprAst(ast, this, this.instance);
 
     this.slotExprMap[slotName] = expr;
 
@@ -313,7 +313,7 @@ export class SqrlCompiledOutput extends SqrlParseInfo {
         return null;
       }
 
-      return SqrlJs.generateExpr(this.functionRegistry, fetchExpr);
+      return SqrlJs.generateExpr(this.instance, fetchExpr);
     });
   }
 

--- a/packages/sqrl/src/compile/compileLabelerStatements.ts
+++ b/packages/sqrl/src/compile/compileLabelerStatements.ts
@@ -35,7 +35,7 @@ export function labelerPushStatement(
   parserState: SqrlParserState,
   ast: Ast
 ): void {
-  const functionRegistry = parserState.functionRegistry;
+  const instance = parserState.instance;
 
   sqrlInvariant(
     ast,
@@ -90,11 +90,11 @@ export function labelerPushStatement(
     const func = resultAst.func;
     sqrlInvariant(
       ast,
-      functionRegistry.isStatement(func),
+      instance.isStatement(func),
       `Function '${func}' was not registered as a statement`
     );
 
-    const statementFeature = functionRegistry.statementFeature(func);
+    const statementFeature = instance.statementFeature(func);
     const registeredCall = SqrlAst.registerCall(resultAst);
     parserState.addStatement(
       ast,
@@ -104,7 +104,7 @@ export function labelerPushStatement(
   } else if (ast.type === "call") {
     parserState.addCallStatement(ast, ast);
   } else if (ast.type === "listComprehension") {
-    functionRegistry.assertStatementAst(ast.output);
+    instance.assertStatementAst(ast.output);
     const funcAst = ast.output;
     const newAst = Object.assign({}, ast, {
       output: SqrlAst.registerCall(ast.output)
@@ -117,7 +117,7 @@ export function labelerPushStatement(
       );
     }
 
-    const statementFeature = functionRegistry.statementFeature(funcAst.func);
+    const statementFeature = instance.statementFeature(funcAst.func);
     parserState.addStatement(ast, statementFeature, newAst);
   } else if (ast.type === "when") {
     compileWhenBlock(parserState, ast);

--- a/packages/sqrl/src/compile/compileWhenBlock.ts
+++ b/packages/sqrl/src/compile/compileWhenBlock.ts
@@ -43,7 +43,7 @@ export function compileWhenBlock(state: SqrlParserState, ast: WhenAst) {
       );
     }
     const { func } = statement;
-    const props = state.functionRegistry.getProps(func);
+    const props = state.instance.getProps(func);
 
     const args = props.args;
     if (!Array.isArray(args)) {
@@ -64,7 +64,7 @@ export function compileWhenBlock(state: SqrlParserState, ast: WhenAst) {
 
     sqrlInvariant(
       statement,
-      state.functionRegistry.isStatement(func) &&
+      state.instance.isStatement(func) &&
         props.stateArg &&
         props.whenCauseArg,
       `Function '${func}' must have a state and when context argument for use in a WHEN block`

--- a/packages/sqrl/src/execute/JsExecutionContext.ts
+++ b/packages/sqrl/src/execute/JsExecutionContext.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { SqrlFunctionRegistry } from "../function/FunctionRegistry";
+import { SqrlInstance } from "../function/Instance";
 import bluebird = require("bluebird");
 import vm = require("vm");
 
@@ -13,10 +13,10 @@ export class JsExecutionContext {
   private sandbox: vm.Context;
   private cache: { [js: string]: JsCallback } = {};
 
-  constructor(functionRegistry: SqrlFunctionRegistry) {
+  constructor(instance: SqrlInstance) {
     this.sandbox = vm.createContext({
       console,
-      functions: functionRegistry.functions,
+      functions: instance.functions,
       bluebird
     });
   }

--- a/packages/sqrl/src/function/ArrayFunctions.ts
+++ b/packages/sqrl/src/function/ArrayFunctions.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { AstTypes as AT } from "../ast/AstTypes";
 
 import flatten from "../jslib/flatten";
@@ -14,8 +14,8 @@ function _isStringOrArray(v?) {
   return typeof v === "string" || Array.isArray(v);
 }
 
-export function registerArrayFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerArrayFunctions(instance: StdlibRegistry) {
+  instance.save(
     function dedupe(arr) {
       if (!Array.isArray(arr)) {
         return null;
@@ -42,7 +42,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function sort(arr) {
       if (!Array.isArray(arr)) {
         return null;
@@ -82,7 +82,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _flatten(array) {
       if (!array) {
         return null;
@@ -110,7 +110,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function filter(arr) {
       if (!Array.isArray(arr)) {
         return null;
@@ -126,7 +126,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function first(arr) {
       if (!Array.isArray(arr)) {
         return null;
@@ -142,7 +142,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function concat(...items) {
       if (items.every(i => typeof i === "string" || typeof i === "number")) {
         return items.join("");
@@ -159,7 +159,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function join(arr, by) {
       if (!Array.isArray(arr) || typeof by !== "string") {
         return null;
@@ -173,7 +173,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function last(arr) {
       if (!Array.isArray(arr) || !arr.length) {
         return null;
@@ -189,7 +189,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _contains(seq, value) {
       if (!_isStringOrArray(seq) || seq === null || value === null) {
         return null;
@@ -206,7 +206,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function index(state, seq, index) {
       if (Array.isArray(seq)) {
         return index >= seq.length ? null : seq[index];
@@ -224,7 +224,7 @@ export function registerArrayFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function length(seq) {
       if (!_isStringOrArray(seq)) {
         return null;

--- a/packages/sqrl/src/function/AssertFunctions.ts
+++ b/packages/sqrl/src/function/AssertFunctions.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "../function/FunctionRegistry";
+import { StdlibRegistry } from "../function/Instance";
 import { AstTypes as AT } from "../ast/AstTypes";
 import { Ast, CallAst } from "../ast/Ast";
 
@@ -41,12 +41,12 @@ export class SimpleAssertService implements AssertService {
 }
 
 export function registerAssertFunctions(
-  registry: StdlibRegistry,
+  instance: StdlibRegistry,
   service?: AssertService
 ) {
   service = service || new SimpleAssertService();
 
-  registry.save(
+  instance.save(
     function _assert(state: SqrlExecutionState, value, arrow) {
       service.ok(state.manipulator, value, arrow);
     },
@@ -59,7 +59,7 @@ export function registerAssertFunctions(
     }
   );
 
-  registry.save(
+  instance.save(
     function _assertCmp(
       state: SqrlExecutionState,
       left: any,
@@ -78,7 +78,7 @@ export function registerAssertFunctions(
     }
   );
 
-  registry.save(null, {
+  instance.save(null, {
     name: "assert",
     statement: true,
     transformAst(state: SqrlParserState, ast: CallAst): Ast {

--- a/packages/sqrl/src/function/BoolFunctions.ts
+++ b/packages/sqrl/src/function/BoolFunctions.ts
@@ -5,11 +5,11 @@
  */
 
 import { AstTypes as AT } from "../ast/AstTypes";
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { SqrlObject } from "../object/SqrlObject";
 
-export function registerBoolFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerBoolFunctions(instance: StdlibRegistry) {
+  instance.save(
     function _and(...args) {
       let seenNull = false;
       for (const arg of args) {
@@ -31,7 +31,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _not(value) {
       if (value === null) {
         return null;
@@ -49,7 +49,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     async function _andSequential(state, callbacks) {
       let arg;
       let seenNull = false;
@@ -74,7 +74,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _isNull(value) {
       return value === null;
     },
@@ -86,7 +86,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     async function choice(state, ...promises) {
       for (const p of promises) {
         const arg = await p;
@@ -108,7 +108,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function coalesce(...args) {
       for (const arg of args) {
         if (arg !== null) {
@@ -125,7 +125,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _or(...args) {
       let hadNull = false;
       for (const arg of args) {
@@ -146,7 +146,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     async function _orSequential(state, callbacks) {
       let hadNull = false;
       for (const callback of callbacks) {
@@ -170,7 +170,7 @@ export function registerBoolFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _orParallel(state, ...promises) {
       return new Promise(resolve => {
         let remaining = promises.length;

--- a/packages/sqrl/src/function/ComparisonFunctions.ts
+++ b/packages/sqrl/src/function/ComparisonFunctions.ts
@@ -3,46 +3,46 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { cmpE, cmpNE, cmpG, cmpGE, cmpL, cmpLE } from "sqrl-common";
 import { AstTypes as AT } from "../ast/AstTypes";
 
-export function registerComparisonFunctions(registry: StdlibRegistry) {
+export function registerComparisonFunctions(instance: StdlibRegistry) {
   const compareOpts = {
     args: [AT.any, AT.any],
     pure: true,
     argstring: "value, value"
   };
-  registry.save(cmpE, {
+  instance.save(cmpE, {
     ...compareOpts,
     name: "_cmpE",
     docstring:
       "Returns true if the first argument is equal to the second argument"
   });
-  registry.save(cmpNE, {
+  instance.save(cmpNE, {
     ...compareOpts,
     name: "_cmpNE",
     docstring:
       "Returns true if the first argument is not equal to the second argument"
   });
-  registry.save(cmpG, {
+  instance.save(cmpG, {
     ...compareOpts,
     name: "_cmpG",
     docstring:
       "Returns true if the first argument is greater than second argument"
   });
-  registry.save(cmpGE, {
+  instance.save(cmpGE, {
     ...compareOpts,
     name: "_cmpGE",
     docstring:
       "Returns true if the first argument is greater than or equal to second argument"
   });
-  registry.save(cmpL, {
+  instance.save(cmpL, {
     ...compareOpts,
     name: "_cmpL",
     docstring: "Returns true if the first argument is less than second argument"
   });
-  registry.save(cmpLE, {
+  instance.save(cmpLE, {
     ...compareOpts,
     name: "_cmpLE",
     docstring:

--- a/packages/sqrl/src/function/ControlFunctions.ts
+++ b/packages/sqrl/src/function/ControlFunctions.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { Ast, CallAst } from "../ast/Ast";
 import { AstTypes as AT } from "../ast/AstTypes";
 
@@ -15,8 +15,8 @@ import { SqrlObject } from "../object/SqrlObject";
 
 export const INPUT_FUNCTION = "input";
 
-export function registerControlFunctions(registry: StdlibRegistry) {
-  registry.save(null, {
+export function registerControlFunctions(instance: StdlibRegistry) {
+  instance.save(null, {
     name: "if",
     allowNull: true,
     transformAst(state: SqrlParserState, ast: CallAst): Ast {
@@ -34,7 +34,7 @@ export function registerControlFunctions(registry: StdlibRegistry) {
       "Returns either the true_result or false_result based on the condition"
   });
 
-  registry.save(
+  instance.save(
     function ifNull(test, valueIfNull) {
       if (test === null) {
         return valueIfNull;
@@ -52,7 +52,7 @@ export function registerControlFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(null, {
+  instance.save(null, {
     name: INPUT_FUNCTION,
     transformAst(state, ast: CallAst) {
       throw new Error(
@@ -63,11 +63,11 @@ export function registerControlFunctions(registry: StdlibRegistry) {
     docstring: "Sets the given feature as an input value"
   });
 
-  registry.save(function _slotWait() {
+  instance.save(function _slotWait() {
     throw new Error("This function is a language builtin");
   });
 
-  registry.save(null, {
+  instance.save(null, {
     name: "wait",
     transformAst(state, ast: CallAst): CallAst {
       return SqrlAst.call(
@@ -85,7 +85,7 @@ export function registerControlFunctions(registry: StdlibRegistry) {
       "Function that returns once all of the input features have been calculated"
   });
 
-  registry.save(
+  instance.save(
     async function _listComprehension(
       state,
       iterator,

--- a/packages/sqrl/src/function/DataFunctions.ts
+++ b/packages/sqrl/src/function/DataFunctions.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { Ast } from "../ast/Ast";
 
 import { AstTypes as AT } from "../ast/AstTypes";
@@ -18,8 +18,8 @@ import { sqrlInvariant } from "../api/parse";
 // $[ (digits / single quoted string / double quoted string) ] (anything)
 const JSON_BRAKET_REGEX = /^\$\[([0-9]+|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*")\](.*)$/;
 
-export function registerDataFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerDataFunctions(instance: StdlibRegistry) {
+  instance.save(
     function attr(data: any, key: string | number): any {
       if (data instanceof SqrlObject) {
         data = data.getBasicValue();
@@ -45,7 +45,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function hasAttr(data, key) {
       if (
         data === null ||
@@ -64,7 +64,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function keys(data) {
       if (data === null || typeof data !== "object") {
         return null;
@@ -79,7 +79,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function jsonParse(raw: string) {
       return JSON.parse(raw);
     },
@@ -90,7 +90,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(null, {
+  instance.save(null, {
     name: "jsonValue",
     args: [AT.any, AT.constant.string],
     argstring: "object, path string",
@@ -137,7 +137,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     }
   });
 
-  registry.save(
+  instance.save(
     function _jsonPath(data, path) {
       return jsonpath.query(data, path);
     },
@@ -146,7 +146,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(null, {
+  instance.save(null, {
     name: "jsonPath",
     args: [AT.any, AT.any],
     transformAst(state: SqrlParserState, ast): Ast {
@@ -161,7 +161,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     docstring: "Returns the values matching the given JSONPath query"
   });
 
-  registry.save(
+  instance.save(
     function _createMap(...items) {
       const result = {};
       for (let idx = 0; idx < items.length; idx += 2) {
@@ -176,7 +176,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(null, {
+  instance.save(null, {
     name: "createMap",
     transformAst(state, ast): Ast {
       sqrlInvariant(
@@ -191,7 +191,7 @@ export function registerDataFunctions(registry: StdlibRegistry) {
     docstring: "Create a map given the key, value pairs"
   });
 
-  registry.save(
+  instance.save(
     function mergeMaps(...objects) {
       return Object.assign({}, ...objects);
     },

--- a/packages/sqrl/src/function/DateFunctions.ts
+++ b/packages/sqrl/src/function/DateFunctions.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { Ast, CallAst } from "../ast/Ast";
 
 import { AstTypes as AT } from "../ast/AstTypes";
@@ -44,8 +44,8 @@ function timeMsForValue(value: any) {
 
   throw new Error("Invalid time value passed to timeMs");
 }
-export function registerDateFunctions(registry: StdlibRegistry) {
-  registry.save(null, {
+export function registerDateFunctions(instance: StdlibRegistry) {
+  instance.save(null, {
     name: "dateDiff",
     args: [AT.constant.string, AT.any, AT.any.optional],
     transformAst(state: SqrlParserState, ast: CallAst): Ast {
@@ -82,7 +82,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
       "Returns the difference between the two dates in the given unit (millisecond, second, minute, hour, day, week)"
   });
 
-  registry.save(
+  instance.save(
     function _dateDiff(msConversion: number, start, end) {
       start = timeMsForValue(start);
       end = timeMsForValue(end);
@@ -93,7 +93,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _formatDate(timeMs, format) {
       if (timeMs instanceof SqrlObject) {
         timeMs = timeMs.tryGetTimeMs();
@@ -110,7 +110,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(null, {
+  instance.save(null, {
     name: "formatDate",
     args: [AT.any, AT.any.optional],
     transformAst(state: SqrlParserState, ast: CallAst): Ast {
@@ -137,7 +137,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
       "Format a given date according to a given format (see https://momentjs.com/docs/#/displaying/format/)"
   });
 
-  registry.save(
+  instance.save(
     function _dateAdd(time, duration) {
       time = timeMsForValue(time);
       const value = Moment.utc(time)
@@ -153,7 +153,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(null, {
+  instance.save(null, {
     name: "dateAdd",
     transformAst(state: SqrlParserState, ast: CallAst): Ast {
       sqrlInvariant(
@@ -179,7 +179,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
     docstring: "Add a given duration (ISO8601 format) to the given date"
   });
 
-  registry.save(
+  instance.save(
     function date(value) {
       return new SqrlDateTime(timeMsForValue(value));
     },
@@ -191,7 +191,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function dateFromMs(ms: number) {
       return ms && new SqrlDateTime(ms);
     },
@@ -203,7 +203,7 @@ export function registerDateFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function timeMs(state: Execution, timeValue) {
       return timeMsForValue(timeValue);
     },

--- a/packages/sqrl/src/function/EntityFunctions.ts
+++ b/packages/sqrl/src/function/EntityFunctions.ts
@@ -3,14 +3,14 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 
 import { AstTypes as AT } from "../ast/AstTypes";
 import { SqrlExecutionState } from "../execute/SqrlExecutionState";
 import SqrlEntity from "../object/SqrlEntity";
 
-export function registerEntityFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerEntityFunctions(instance: StdlibRegistry) {
+  instance.save(
     function uniqueId(state: SqrlExecutionState, uniqueId: SqrlEntity) {
       return uniqueId.getNumberString();
     },
@@ -22,7 +22,7 @@ export function registerEntityFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function entityId(state: SqrlExecutionState, entity: SqrlEntity) {
       return entity.entityId.getIdString();
     },

--- a/packages/sqrl/src/function/Instance.ts
+++ b/packages/sqrl/src/function/Instance.ts
@@ -149,7 +149,7 @@ function syncSafetyNet(name: string, fn, config: SafetyNetConfig) {
 
 export class StdlibRegistry {
   constructor(
-    public wrapped: SqrlFunctionRegistry,
+    public wrapped: SqrlInstance,
     public packageName: string
   ) {}
 
@@ -164,7 +164,7 @@ export class StdlibRegistry {
   }
 }
 
-export class SqrlFunctionRegistry {
+export class SqrlInstance {
   // Use integers for calculation
   static intCostMultiplier = 100000;
 

--- a/packages/sqrl/src/function/KeyFunctions.ts
+++ b/packages/sqrl/src/function/KeyFunctions.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 
 import { SqrlKey } from "../object/SqrlKey";
 
@@ -72,8 +72,8 @@ async function getKeyList(
   );
 }
 
-export function registerKeyFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerKeyFunctions(instance: StdlibRegistry) {
+  instance.save(
     async function buildKeySqrl(
       state: SqrlExecutionState,
       counterEntity: SqrlEntity,
@@ -92,7 +92,7 @@ export function registerKeyFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     async function getKeyListSqrl(state: SqrlExecutionState, ...args) {
       const keys = await getKeyList(state.ctx, ...args);
       keys.forEach(key => {

--- a/packages/sqrl/src/function/MathFunctions.ts
+++ b/packages/sqrl/src/function/MathFunctions.ts
@@ -3,18 +3,18 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 
 import { AstTypes as AT } from "../ast/AstTypes";
 
-export function registerMathFunctions(registry: StdlibRegistry) {
+export function registerMathFunctions(instance: StdlibRegistry) {
   const safeMathOpts = {
     args: [AT.any, AT.any],
     pure: true,
     safe: true
   };
 
-  registry.save(
+  instance.save(
     function abs(value) {
       const result = Math.abs(value);
       return isNaN(result) ? null : result;
@@ -26,7 +26,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function random() {
       return Math.random();
     },
@@ -37,7 +37,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function round(value) {
       const result = Math.round(value);
       return isNaN(result) ? null : result;
@@ -62,7 +62,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
     }
   }
 
-  registry.save(
+  instance.save(
     function max(values) {
       values = filterNumberList(values);
       if (values.length === 0) {
@@ -78,7 +78,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function min(values) {
       values = filterNumberList(values);
       if (values.length === 0) {
@@ -94,7 +94,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function sum(values) {
       values = filterNumberList(values);
       if (values.length === 0) {
@@ -110,7 +110,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function log10(value) {
       if (typeof value !== "number") {
         return null;
@@ -125,7 +125,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function _add(left, right) {
       if (typeof left !== "number" || typeof right !== "number") {
         return null;
@@ -138,7 +138,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
       docstring: "Returns the sum of the given numbers"
     }
   );
-  registry.save(
+  instance.save(
     function _subtract(left, right) {
       if (typeof left !== "number" || typeof right !== "number") {
         return null;
@@ -151,7 +151,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
       docstring: "Returns the difference of the given numbers"
     }
   );
-  registry.save(
+  instance.save(
     function _multiply(left, right) {
       if (typeof left !== "number" || typeof right !== "number") {
         return null;
@@ -166,7 +166,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
   );
 
   // modulo is special due to division by zero error
-  registry.save(
+  instance.save(
     function _modulo(state, left, right) {
       if (right === 0) {
         state.logError(new Error("Modulo by zero"));
@@ -184,7 +184,7 @@ export function registerMathFunctions(registry: StdlibRegistry) {
   );
 
   // Divide is special due to division by zero error
-  registry.save(
+  instance.save(
     function _divide(state, left, right) {
       if (typeof left !== "number" || typeof right !== "number") {
         return null;

--- a/packages/sqrl/src/function/StringFunctions.ts
+++ b/packages/sqrl/src/function/StringFunctions.ts
@@ -5,12 +5,12 @@
  */
 /* eslint-disable no-useless-escape */
 
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { AstTypes as AT } from "../ast/AstTypes";
 import { SqrlObject } from "../object/SqrlObject";
 
-export function registerStringFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerStringFunctions(instance: StdlibRegistry) {
+  instance.save(
     function repr(value) {
       if (value === null) {
         return "null";
@@ -36,7 +36,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function stringify(value) {
       return JSON.stringify(value);
     },
@@ -46,7 +46,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
       docstring: "Returns the value encoded as a json string"
     }
   );
-  registry.save(
+  instance.save(
     function hexEncode(string) {
       return Buffer.from(string, "utf-8").toString("hex");
     },
@@ -57,7 +57,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function strip(string) {
       return typeof string === "string" ? string.trim() : null;
     },
@@ -69,7 +69,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function escapeURI(string) {
       return encodeURIComponent(string);
     },
@@ -81,7 +81,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function escapeRegex(state, str) {
       return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
     },
@@ -93,7 +93,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function split(string, by) {
       if (typeof string !== "string" || typeof by !== "string") {
         return null;
@@ -107,7 +107,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function iso8601(value) {
       if (value instanceof SqrlObject) {
         const timeMs = value.getTimeMs();
@@ -123,7 +123,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function lower(string) {
       return typeof string === "string" ? string.toLowerCase() : null;
     },
@@ -133,7 +133,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
       docstring: "Returns the lowercase version of the given string"
     }
   );
-  registry.save(
+  instance.save(
     function upper(string) {
       return typeof string === "string" ? string.toUpperCase() : null;
     },
@@ -143,7 +143,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
       docstring: "Returns the uppercase version of the given string"
     }
   );
-  registry.save(
+  instance.save(
     function hasDigit(string) {
       return typeof string === "string" ? /[0-9]/.test(string) : null;
     },
@@ -154,7 +154,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function startsWith(string, prefix) {
       if (typeof string !== "string" || typeof prefix !== "string") {
         return null;
@@ -168,7 +168,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function endsWith(string, suffix) {
       if (typeof string !== "string" || typeof suffix !== "string") {
         return null;
@@ -182,7 +182,7 @@ export function registerStringFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function substr(state, string, start, end = null) {
       return string.substr(...[start, end].filter(v => v !== null));
     },

--- a/packages/sqrl/src/function/TimeFunctions.ts
+++ b/packages/sqrl/src/function/TimeFunctions.ts
@@ -3,12 +3,12 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { AstTypes as AT } from "../ast/AstTypes";
 import bluebird = require("bluebird");
 
-export function registerTimeFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerTimeFunctions(instance: StdlibRegistry) {
+  instance.save(
     function now() {
       return new Date().toISOString();
     },
@@ -20,7 +20,7 @@ export function registerTimeFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function nowMs() {
       return Date.now();
     },
@@ -33,7 +33,7 @@ export function registerTimeFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function delayMs(state, ms, value) {
       return bluebird.delay(ms).thenReturn(value);
     },

--- a/packages/sqrl/src/function/TypeFunctions.ts
+++ b/packages/sqrl/src/function/TypeFunctions.ts
@@ -4,7 +4,7 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 import { SqrlObject } from "../object/SqrlObject";
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { AstTypes as AT } from "../ast/AstTypes";
 
 const FLOAT_REGEX = /^-?[0-9]*(\.[0-9]+)?$/;
@@ -37,8 +37,8 @@ function int(value: any): number | null {
 
   return Math.floor(value);
 }
-export function registerTypeFunctions(registry: StdlibRegistry) {
-  registry.save(int, {
+export function registerTypeFunctions(instance: StdlibRegistry) {
+  instance.save(int, {
     args: [AT.any],
     pure: true,
     allowSqrlObjects: true,
@@ -46,7 +46,7 @@ export function registerTypeFunctions(registry: StdlibRegistry) {
     docstring: "Returns the integer value of the given input value"
   });
 
-  registry.save(SqrlObject.isTruthy, {
+  instance.save(SqrlObject.isTruthy, {
     name: "bool",
     args: [AT.any],
     allowSqrlObjects: true,
@@ -55,7 +55,7 @@ export function registerTypeFunctions(registry: StdlibRegistry) {
     docstring: "Returns the boolean value of the given input value"
   });
 
-  registry.save(float, {
+  instance.save(float, {
     args: [AT.any],
     pure: true,
     allowSqrlObjects: true,
@@ -63,7 +63,7 @@ export function registerTypeFunctions(registry: StdlibRegistry) {
     docstring: "Returns the floating point value of the given input value"
   });
 
-  registry.save(
+  instance.save(
     function list(...values) {
       return values;
     },
@@ -75,7 +75,7 @@ export function registerTypeFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function str(value) {
       if (Array.isArray(value)) {
         return "[array]";
@@ -96,7 +96,7 @@ export function registerTypeFunctions(registry: StdlibRegistry) {
     }
   );
 
-  registry.save(
+  instance.save(
     function basic(value) {
       return value;
     },

--- a/packages/sqrl/src/function/WhenFunctions.ts
+++ b/packages/sqrl/src/function/WhenFunctions.ts
@@ -4,14 +4,14 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 import { AstTypes as AT } from "../ast/AstTypes";
-import { StdlibRegistry } from "./FunctionRegistry";
+import { StdlibRegistry } from "./Instance";
 import { SqrlExecutionState } from "../execute/SqrlExecutionState";
 import invariant from "../jslib/invariant";
 import { REASON_FEATURE_REGEX } from "../slot/SqrlRuleSlot";
 import { WhenCause, FiredRule } from "../api/when";
 export { WhenCause, FiredRule };
-export function registerWhenFunctions(registry: StdlibRegistry) {
-  registry.save(
+export function registerWhenFunctions(instance: StdlibRegistry) {
+  instance.save(
     function _buildWhenCause(
       state: SqrlExecutionState,
       ruleNames: string[],

--- a/packages/sqrl/src/function/registerAllFunctions.ts
+++ b/packages/sqrl/src/function/registerAllFunctions.ts
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { SqrlFunctionRegistry } from "./FunctionRegistry";
+import { SqrlInstance } from "./Instance";
 import { registerBoolFunctions } from "./BoolFunctions";
 import { registerTypeFunctions } from "./TypeFunctions";
 import { registerComparisonFunctions } from "./ComparisonFunctions";
@@ -21,24 +21,24 @@ import { registerWhenFunctions } from "./WhenFunctions";
 import { FunctionServices } from "../api/execute";
 
 export function registerAllFunctions(
-  functionRegistry: SqrlFunctionRegistry,
+  instance: SqrlInstance,
   services: FunctionServices = {}
 ) {
-  registerTypeFunctions(functionRegistry.createStdlibRegistry("type"));
-  registerBoolFunctions(functionRegistry.createStdlibRegistry("bool"));
-  registerComparisonFunctions(functionRegistry.createStdlibRegistry("compare"));
-  registerMathFunctions(functionRegistry.createStdlibRegistry("math"));
-  registerControlFunctions(functionRegistry.createStdlibRegistry("control"));
-  registerWhenFunctions(functionRegistry.createStdlibRegistry("when"));
+  registerTypeFunctions(instance.createStdlibRegistry("type"));
+  registerBoolFunctions(instance.createStdlibRegistry("bool"));
+  registerComparisonFunctions(instance.createStdlibRegistry("compare"));
+  registerMathFunctions(instance.createStdlibRegistry("math"));
+  registerControlFunctions(instance.createStdlibRegistry("control"));
+  registerWhenFunctions(instance.createStdlibRegistry("when"));
   registerAssertFunctions(
-    functionRegistry.createStdlibRegistry("assert"),
+    instance.createStdlibRegistry("assert"),
     services.assert
   );
-  registerEntityFunctions(functionRegistry.createStdlibRegistry("entity"));
-  registerKeyFunctions(functionRegistry.createStdlibRegistry("key"));
-  registerArrayFunctions(functionRegistry.createStdlibRegistry("list"));
-  registerDataFunctions(functionRegistry.createStdlibRegistry("data"));
-  registerDateFunctions(functionRegistry.createStdlibRegistry("date-time"));
-  registerTimeFunctions(functionRegistry.createStdlibRegistry("date-time"));
-  registerStringFunctions(functionRegistry.createStdlibRegistry("string"));
+  registerEntityFunctions(instance.createStdlibRegistry("entity"));
+  registerKeyFunctions(instance.createStdlibRegistry("key"));
+  registerArrayFunctions(instance.createStdlibRegistry("list"));
+  registerDataFunctions(instance.createStdlibRegistry("data"));
+  registerDateFunctions(instance.createStdlibRegistry("date-time"));
+  registerTimeFunctions(instance.createStdlibRegistry("date-time"));
+  registerStringFunctions(instance.createStdlibRegistry("string"));
 }

--- a/packages/sqrl/src/helpers/InstanceHelpers.ts
+++ b/packages/sqrl/src/helpers/InstanceHelpers.ts
@@ -3,12 +3,12 @@
  * Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0
  */
-import { SqrlFunctionRegistry } from "../function/FunctionRegistry";
+import { SqrlInstance } from "../function/Instance";
 import { registerAllFunctions } from "../function/registerAllFunctions";
 import { FunctionServices } from "../api/execute";
 
-export function buildFunctionRegistryForServices(services: FunctionServices) {
-  const registry = new SqrlFunctionRegistry();
-  registerAllFunctions(registry);
-  return registry;
+export function buildSqrlInstanceForServices(services: FunctionServices) {
+  const instance = new SqrlInstance();
+  registerAllFunctions(instance);
+  return instance;
 }

--- a/packages/sqrl/src/js/SqrlJs.ts
+++ b/packages/sqrl/src/js/SqrlJs.ts
@@ -13,7 +13,7 @@ import {
   IfExpr,
   CallExpr
 } from "../expr/Expr";
-import { SqrlFunctionRegistry } from "../function/FunctionRegistry";
+import { SqrlInstance } from "../function/Instance";
 
 class ConstantJsExpr {
   usedPromise: boolean = false;
@@ -68,7 +68,7 @@ class JsState {
   constants: ConstantJsExpr[];
   iterator: boolean;
 
-  constructor(public functionRegistry: SqrlFunctionRegistry) {
+  constructor(public instance: SqrlInstance) {
     this.functionsJs = [];
     this.constants = [];
     this.iterator = false;
@@ -228,7 +228,7 @@ function ifToJs(expr: IfExpr, state: JsState) {
 }
 
 function callToJs(expr: CallExpr, state: JsState): JsExpr {
-  const funcProps = state.functionRegistry.getProps(expr.func);
+  const funcProps = state.instance.getProps(expr.func);
   const exprJs = expr.exprs.map(item => exprToJs(item, state));
 
   if (funcProps.callbackArgs === true) {
@@ -348,8 +348,8 @@ function exprToJs(expr: Expr, state: JsState): JsExpr {
 }
 
 export const SqrlJs = {
-  generateExpr(functionRegistry: SqrlFunctionRegistry, expr: Expr) {
-    const state = new JsState(functionRegistry);
+  generateExpr(instance: SqrlInstance, expr: Expr) {
+    const state = new JsState(instance);
     const js = exprToJs(expr, state);
     return state.buildExpr(js);
   }

--- a/packages/sqrl/src/simple/runSqrlTest.ts
+++ b/packages/sqrl/src/simple/runSqrlTest.ts
@@ -7,24 +7,24 @@ import { SimpleManipulator } from "./SimpleManipulator";
 import { createSimpleContext } from "../api/ctx";
 import { SqrlTest } from "../testing/SqrlTest";
 import { LocalFilesystem, Filesystem } from "../api/filesystem";
-import { buildTestFunctionRegistry } from "../testing/runSqrlTest";
-import { FunctionRegistry, Execution } from "../api/execute";
+import { buildTestInstance } from "../testing/runSqrlTest";
+import { Instance, Execution } from "../api/execute";
 import * as path from "path";
 import { Logger } from "../api/log";
 import { Config } from "../api/config";
-import { FunctionCostData } from "../function/FunctionRegistry";
+import { FunctionCostData } from "../function/Instance";
 import { invariant } from "sqrl-common";
 
 export async function runSqrlTest(
   sqrl: string,
   options: {
     config?: Config;
-    functionRegistry?: FunctionRegistry;
+    instance?: Instance;
     functionCost?: FunctionCostData;
     logger?: Logger;
     filesystem?: Filesystem;
     librarySqrl?: string;
-    register?: (instance: FunctionRegistry) => Promise<void>;
+    register?: (instance: Instance) => Promise<void>;
   } = {}
 ): Promise<{
   codedErrors: Error[];
@@ -32,33 +32,33 @@ export async function runSqrlTest(
   lastExecution: Execution;
   lastManipulator: SimpleManipulator;
 }> {
-  let functionRegistry: FunctionRegistry;
+  let instance: Instance;
 
-  if (options.functionRegistry) {
+  if (options.instance) {
     invariant(
       !options.config,
-      "config option not valid when functionRegistry is provided"
+      "config option not valid when instance is provided"
     );
     invariant(
       !options.functionCost,
-      "functionCost option not valid when functionRegistry is provided"
+      "functionCost option not valid when instance is provided"
     );
-    functionRegistry = options.functionRegistry;
+    instance = options.instance;
   } else {
-    functionRegistry = await buildTestFunctionRegistry({
+    instance = await buildTestInstance({
       functionCost: options.functionCost,
       config: options.config
     });
   }
 
   if (options.register) {
-    await options.register(functionRegistry);
+    await options.register(instance);
   }
 
   const filesystem =
     options.filesystem || new LocalFilesystem(path.join(__dirname, ".."));
 
-  const test = new SqrlTest(functionRegistry._functionRegistry, {
+  const test = new SqrlTest(instance._instance, {
     manipulatorFactory: () => new SimpleManipulator(),
     filesystem
   });

--- a/packages/sqrl/src/testing/SqrlTest.ts
+++ b/packages/sqrl/src/testing/SqrlTest.ts
@@ -10,7 +10,7 @@ import { SqrlParserState } from "../compile/SqrlParserState";
 
 import { StatementAst } from "../ast/Ast";
 import { parseSqrl } from "../parser/SqrlParse";
-import { SqrlFunctionRegistry } from "../function/FunctionRegistry";
+import { SqrlInstance } from "../function/Instance";
 import { SqrlCompiledOutput } from "../compile/SqrlCompiledOutput";
 import { JsExecutionContext } from "../execute/JsExecutionContext";
 import SqrlSourcePrinter from "../compile/SqrlSourcePrinter";
@@ -42,7 +42,7 @@ export class SqrlTest {
   private filesystem: Filesystem;
 
   constructor(
-    private functionRegistry: SqrlFunctionRegistry,
+    private instance: SqrlInstance,
     props: {
       files?: any;
       inputs?: FeatureMap;
@@ -56,7 +56,7 @@ export class SqrlTest {
     } = {}
   ) {
     this.featureTimeout = props.featureTimeout || DEFAULT_FEATURE_TIMEOUT;
-    this.executionContext = new JsExecutionContext(functionRegistry);
+    this.executionContext = new JsExecutionContext(instance);
     this.files = props.files || {};
     this.extendTimeout =
       props.extendTimeout ||
@@ -77,7 +77,7 @@ export class SqrlTest {
 
   async run(ctx: Context, sqrl: string) {
     const statements = parseSqrl(sqrl, {
-      customFunctions: this.functionRegistry.customFunctions
+      customFunctions: this.instance.customFunctions
     }).statements;
     return this.runStatements(ctx, statements);
   }
@@ -169,7 +169,7 @@ export class SqrlTest {
       allowAssertions: true,
       allowReplaceInput: true,
       allowPrivate: this.allowPrivate,
-      functionRegistry: this.functionRegistry,
+      instance: this.instance,
       filesystem: this.filesystem
     });
 

--- a/packages/sqrl/src/testing/runSqrlTest.ts
+++ b/packages/sqrl/src/testing/runSqrlTest.ts
@@ -4,12 +4,12 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 import {
-  SqrlFunctionRegistry,
+  SqrlInstance,
   FunctionCostData
-} from "../function/FunctionRegistry";
+} from "../function/Instance";
 import { registerAllFunctions } from "../function/registerAllFunctions";
 import { AssertService } from "sqrl-common";
-import { FunctionRegistry, FunctionServices } from "../api/execute";
+import { Instance, FunctionServices } from "../api/execute";
 import { getDefaultConfig, Config } from "../api/config";
 
 export class CapturingAssertService implements AssertService {
@@ -44,14 +44,14 @@ export class CapturingAssertService implements AssertService {
   }
 }
 
-export async function buildTestFunctionRegistry(
+export async function buildTestInstance(
   options: {
     config?: Config;
     functionCost?: FunctionCostData;
     services?: FunctionServices;
   } = {}
 ) {
-  const functionRegistry = new SqrlFunctionRegistry({
+  const instance = new SqrlInstance({
     functionCost: options.functionCost
   });
 
@@ -64,16 +64,16 @@ export async function buildTestFunctionRegistry(
     assert = new CapturingAssertService();
   }
 
-  registerAllFunctions(functionRegistry, {
+  registerAllFunctions(instance, {
     assert,
     ...(options.services || {})
   });
-  return new FunctionRegistry(
+  return new Instance(
     {
       ...getDefaultConfig(),
       "state.allow-in-memory": true,
       ...(options.config || {})
     },
-    functionRegistry
+    instance
   );
 }

--- a/website/source/functions/simple.md
+++ b/website/source/functions/simple.md
@@ -16,10 +16,10 @@ npm install --save sqrl sqrl-cli
 Once the packages are installed you can create a basic registration function
 
 ```
-import {FunctionRegistry, Execution, AT } from "sqrl"
+import {Instance, Execution, AT } from "sqrl"
 
-function registerFunctions(functionRegistry: FunctionRegistry) => {
-    functionRegistry.register(async function sayHello(state: Execution, name) {
+function registerFunctions(instance: Instance) => {
+    instance.register(async function sayHello(state: Execution, name) {
         return 'Hello, ' + name + '!';
     }, {
         args: [AT.state, AT.any]

--- a/website/source/language/cost.md
+++ b/website/source/language/cost.md
@@ -7,8 +7,8 @@ In order to reduce cost SQRL allows you to optimize `AND` and `OR` conditions. T
 in your production environment and passed into the instance.
 
 ```
-import { buildInstance } from "sqrl";
-const instance = buildInstance({
+import { createInstance } from "sqrl";
+const instance = createInstance({
     functionCost: {
         expensiveFunction: 10000,
         cheapFunction: 35


### PR DESCRIPTION
# Problem

The old FunctionRegistry name is no longer suitable because it contains more information about the instance of SQRL: configuration information, production cost data, etc.

# Solution

Renamed to `Instance`

# Result

Easier to understand, for me anyway.