### PR TITLE
Fix typo in early preview text

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SQRL is a Safe, Stateful Rules Language for Event Streams
 
 ## Early Preview
 
-This is an early preview of the SQRL (Smyte Query and Rules Language) open-source release. This release is intended to onboard existing community members and prepare us for the full in the near future. Through SQRL, we hope to partner with the open source community, and help better address spam on all websites
+This is an early preview of the SQRL (Smyte Query and Rules Language) open-source release. This release is intended to onboard existing community members and prepare us for a full release in the near future. Through SQRL, we hope to partner with the open source community, and help better address spam on all websites.
 
 ## Documentation
 

--- a/website/source/index.md
+++ b/website/source/index.md
@@ -10,7 +10,7 @@ title: Home
 
 ## Early Preview
 
-This is an early preview of the SQRL (Smyte Query and Rules Language) open-source release. This release is intended to onboard existing community members and prepare us for the full in the near future. Through SQRL, we hope to partner with the open source community, and help better address spam on all websites
+This is an early preview of the SQRL (Smyte Query and Rules Language) open-source release. This release is intended to onboard existing community members and prepare us for a full release in the near future. Through SQRL, we hope to partner with the open source community, and help better address spam on all websites.
 
 ## Community
 


### PR DESCRIPTION
Just a minor fix for the language under Early Preview