### PR TITLE
Lock NodeJS current version for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - SQRL_TEST_REDIS=localhost:6379
 matrix:
   include:
-    - node_js: "node"
+    - node_js: "11.10.1"
     - node_js: "8"
       if: type = push AND branch = master
     - node_js: "10"


### PR DESCRIPTION
# Problem

Jest is broken in the latest NodeJS, see https://github.com/facebook/jest/issues/8069

# Solution

Don't use the very latest NodeJS until the next Jest release is out.

# Result

Builds should be fixed.