### PR TITLE
Fix sqrl-test-utils ref in package.json

### DIFF
--- a/packages/sqrl/package.json
+++ b/packages/sqrl/package.json
@@ -61,7 +61,7 @@
     "jest-extended": "^0.11.2",
     "pegjs": "^0.10.0",
     "rimraf": "^3.0.0",
-    "sqrl-test-utils": "0.0.0",
+    "sqrl-test-utils": "file:../sqrl-test-utils",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
     "ts-pegjs": "^0.2.6",


### PR DESCRIPTION
Was getting this error:
```
npm ERR! code ETARGET
npm ERR! notarget No matching version found for sqrl-test-utils@0.0.0
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'sqrl'
```

# Problem

Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

# Solution

Describe the modifications you've done.

# Result

What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.
