### PR TITLE
Fix sqrl-cli run with JSON file inputs

### DIFF
--- a/examples/data/tweet.json
+++ b/examples/data/tweet.json
@@ -1,0 +1,1 @@
+{"event": "tweet", "username": "floydophone", "text": "hello world!"}

--- a/examples/extract.sqrl
+++ b/examples/extract.sqrl
@@ -1,0 +1,4 @@
+LET EventData := input();
+LET EventType := jsonValue(EventData, "$.event");
+LET Username := jsonValue(EventData, "$.username");
+LET Text := jsonValue(EventData, "$.text");

--- a/packages/sqrl-cli/__tests__/cli/run.spec.ts
+++ b/packages/sqrl-cli/__tests__/cli/run.spec.ts
@@ -21,6 +21,21 @@ test("works", async () => {
   );
 });
 
+test("works with file inputs", async () => {
+  const stdout = await runCli([
+    "run",
+    examplePath("extract.sqrl"),
+    "-s",
+    'EventData=@' + examplePath("data/tweet.json"),
+    "Text",
+    "Username",
+  ]);
+
+  expect(stripAnsi(stdout).replace(/[0-9]/g, "x")).toEqual(
+    "✓ xxxx-xx-xx xx:xx action was allowed.\n" + 'Text="hello world!"\n' + 'Username="floydophone"\n'
+  );
+});
+
 test("does not work with set after text", async () => {
   // @todo: it would be nice if this worked, but seems like a docopt bug
   await expect(

--- a/packages/sqrl-cli/src/cli/readJsonFile.ts
+++ b/packages/sqrl-cli/src/cli/readJsonFile.ts
@@ -28,7 +28,7 @@ export async function readJsonFile(path: string) {
   }
 }
 
-export async function readJsonFileSync(path: string) {
+export function readJsonFileSync(path: string) {
   let data: Buffer;
   try {
     data = readFileSync(path);


### PR DESCRIPTION
# Problem

Running the cli with JSON file input (`-s EventData=@file.json`) threw an error about promises.

# Solution

The `readJsonSync` method was erroneously marked as `async`

# Result

The cli now works, confirmed with a test case for future.