### PR TITLE
Update readme with maintenance notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# [SQRL](https://twitter.github.io/sqrl/) &middot; [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://github.com/twitter/sqrl/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/sqrl.svg?style=flat)](https://www.npmjs.com/package/sqrl) [![Build Status](https://travis-ci.org/twitter/sqrl.svg?branch=master)](https://travis-ci.org/twitter/sqrl) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/twitter/sqrl/blob/master/CONTRIBUTING.md)
+# SQRL
+
+## No longer maintained by Twitter
+
+This source repository is no longer actively maintained. Please find the maintained version at [github.com/qix/sqrl](https://github.com/qix/sqrl)
+
+## What is SQRL?
 
 The Smyte Query and Rules Language (SQRL) is a Safe, Stateful Rules Language for Event Streams
 


### PR DESCRIPTION
# Problem

I intended to open-source this project while employed at Twitter, but unfortunately that never happened due to a number of reasons. Since I've left Twitter there is no-one actively maintaining this source repository.

I'm planning on working on it, and advertising it publicly. It would be problematic (for both myself and Twitter) if people confused this repository for a maintained version.

# Solution

The ideal solution would be transferring this repo to an account where I can control it and actively maintain it. If you could transfer ownership to https://github.com/organizations/sqrl-lang it would be ideal.

Barring that atleast updating the README with a note (that's what this pull request does) would be a second best.

# Result

Users can find the maintained version of the SQRL projecft easily.
